### PR TITLE
New Command ResetClientAsync. The command resets the client connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Currently this library supports the following methods.
  - ForgetClient (Alias of ForgetClients)
  - ForgetClients
  - UnblockClient
+ - ResetClientConnection
  - ShowClientLogins
  - ListOnlineClients
  - ListAllClients

--- a/UnifiClient/UnifiApi/Client.Clients.cs
+++ b/UnifiClient/UnifiApi/Client.Clients.cs
@@ -53,7 +53,7 @@ namespace UnifiApi
         /// <param name="clientMac">The client MAC address.</param>
         /// <param name="siteName">Name of the site. If null it will use the site specified in the client.</param>
         /// <returns>BoolResponse.</returns>
-        public async Task<BoolResponse> ResetClientAsync(string clientMac, string siteName = null)
+        public async Task<BoolResponse> ResetClientConnectionAsync(string clientMac, string siteName = null)
         {
             var path = $"api/s/{(siteName ?? Site)}/cmd/stamgr";
 

--- a/UnifiClient/UnifiApi/Client.Clients.cs
+++ b/UnifiClient/UnifiApi/Client.Clients.cs
@@ -48,6 +48,23 @@ namespace UnifiApi
         }
 
         /// <summary>
+        /// Reset a client connection. For example to force new DHCP request
+        /// </summary>
+        /// <param name="clientMac">The client MAC address.</param>
+        /// <param name="siteName">Name of the site. If null it will use the site specified in the client.</param>
+        /// <returns>BoolResponse.</returns>
+        public async Task<BoolResponse> ResetClientAsync(string clientMac, string siteName = null)
+        {
+            var path = $"api/s/{(siteName ?? Site)}/cmd/stamgr";
+
+            var oJsonObject = new JObject();
+            oJsonObject.Add("cmd", "kick-sta");
+            oJsonObject.Add("mac", clientMac);
+
+            return await ExecuteBoolCommandAsync(path, oJsonObject);
+        }
+
+        /// <summary>
         /// forget a client device.
         /// </summary>
         /// <param name="clientMacAddress">the client mac address.</param>


### PR DESCRIPTION
The command is usefull when you want to force new DHCP request or to let client to look for better wifi connection.